### PR TITLE
Update for PHP 7 and Windows compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Installation
 ------------
 
  * Copy .htaccess to your root, or update your httpd.conf file with its contents, if you prefer.
+ * Ensure that `mod_rewrite` and `mod_actions` are enabled in your Apache server:
+    - `sudo a2enmod rewrite`
+    - `sudo a2enmod actions`
+    - `sudo systemctl restart apache2` (apply the changes)
  * Copy the markdown directory into your webroot.
 
 Now visit a .md file on your webserver; you should see it as properly styled HTML.

--- a/markdown/handler.php
+++ b/markdown/handler.php
@@ -15,12 +15,23 @@ require('markdown.php');
 $legalExtensions = array('md', 'markdown');
 
 $file = realpath($_SERVER['PATH_TRANSLATED']);
-if($file
-	&& in_array(strtolower(substr($file,strrpos($file,'.')+1)), $legalExtensions)
-	&& substr($file,0,strlen($_SERVER['DOCUMENT_ROOT'])) == $_SERVER['DOCUMENT_ROOT']) {
-	echo Markdown(file_get_contents($file));
-} else {
-	echo "<p>Bad filename given</p>";
+
+if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+	if($file
+		&& in_array(strtolower(substr($file,strrpos($file,'.')+1)), $legalExtensions)
+		&& substr($file,0,strlen($_SERVER['DOCUMENT_ROOT'])) == str_replace('/', '\\', $_SERVER['DOCUMENT_ROOT'])) {
+		echo Markdown(file_get_contents($file));
+	} else {
+		echo "<p>Bad filename given</p>";	
+	}
+} else{
+	if($file
+		&& in_array(strtolower(substr($file,strrpos($file,'.')+1)), $legalExtensions)
+		&& substr($file,0,strlen($_SERVER['DOCUMENT_ROOT'])) == $_SERVER['DOCUMENT_ROOT']) {
+		echo Markdown(file_get_contents($file));
+	} else {
+		echo "<p>Bad filename given</p>";
+	}
 }
 ?>
 </body>

--- a/markdown/handler.php
+++ b/markdown/handler.php
@@ -16,22 +16,18 @@ $legalExtensions = array('md', 'markdown');
 
 $file = realpath($_SERVER['PATH_TRANSLATED']);
 
-if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-	if($file
-		&& in_array(strtolower(substr($file,strrpos($file,'.')+1)), $legalExtensions)
-		&& substr($file,0,strlen($_SERVER['DOCUMENT_ROOT'])) == str_replace('/', '\\', $_SERVER['DOCUMENT_ROOT'])) {
-		echo Markdown(file_get_contents($file));
-	} else {
-		echo "<p>Bad filename given</p>";	
-	}
-} else{
-	if($file
-		&& in_array(strtolower(substr($file,strrpos($file,'.')+1)), $legalExtensions)
-		&& substr($file,0,strlen($_SERVER['DOCUMENT_ROOT'])) == $_SERVER['DOCUMENT_ROOT']) {
-		echo Markdown(file_get_contents($file));
-	} else {
-		echo "<p>Bad filename given</p>";
-	}
+if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {  # Windows OS
+  $documentRoot = str_replace('/', '\\', $_SERVER['DOCUMENT_ROOT']);
+} else {  #Unix OS
+  $documentRoot = $_SERVER['DOCUMENT_ROOT'];
+}
+
+if($file
+	&& in_array(strtolower(substr($file,strrpos($file,'.')+1)), $legalExtensions)
+	&& substr($file,0,strlen($_SERVER['DOCUMENT_ROOT'])) == $documentRoot) {
+	echo Markdown(file_get_contents($file));
+} else {
+	echo "<p>Bad filename given</p>";
 }
 ?>
 </body>

--- a/markdown/markdown.php
+++ b/markdown/markdown.php
@@ -214,8 +214,7 @@ class Markdown_Parser {
 	var $predef_urls = array();
 	var $predef_titles = array();
 
-
-	function Markdown_Parser() {
+	function __construct() {
 	#
 	# Constructor function. Initialize appropriate member variables.
 	#
@@ -236,6 +235,16 @@ class Markdown_Parser {
 		asort($this->document_gamut);
 		asort($this->block_gamut);
 		asort($this->span_gamut);
+	}
+
+	function Markdown_Parser() {
+	#
+	# Constructor function. Initialize appropriate member variables.
+	#
+		// PHP4-style constructor.
+        // This will NOT be invoked, unless a sub-class that extends `foo` calls it.
+        // In that case, call the new-style constructor to keep compatibility.
+		self::__construct();
 	}
 
 


### PR DESCRIPTION
* Fix deprecated design for PHP 7:

`Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP;`

Info: http://php.net/manual/en/migration70.deprecated.php

* Fix error in handler executed in Windows caused by `\` in system paths